### PR TITLE
Store session data in cookies

### DIFF
--- a/app/session-stores/application.js
+++ b/app/session-stores/application.js
@@ -1,0 +1,5 @@
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+
+export default CookieStore.extend({
+  cookieName: 'ilios-lti-course-manager-session'
+});


### PR DESCRIPTION
Without the ember-simple-auth defaults to persistent local storage.