### PR TITLE
rolls back ember-cli-postcss upgrade.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7248,33 +7248,18 @@
       }
     },
     "broccoli-postcss": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-postcss/-/broccoli-postcss-6.0.0.tgz",
-      "integrity": "sha512-XldlgbRag80S5MTkA63PpCzTrjiEh3P1wkuVT0e9HzLK9hgD7VQLucShGoy3a7O1PkCjr2g+1Awg8xJoSqgKCA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-postcss/-/broccoli-postcss-5.1.0.tgz",
+      "integrity": "sha512-f5cHP5g7EFidu9w88WOLTtbk4dd/W7amK0nek08FkmUII2h4W/Je4EV26HtMEm9nb1hKI301wwuEQ5AQRsVYog==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^3.0.0",
-        "broccoli-persistent-filter": "^3.1.1",
+        "broccoli-persistent-filter": "^2.1.0",
         "minimist": ">=1.2.5",
         "object-assign": "^4.1.1",
-        "postcss": "^8.1.4"
+        "postcss": "^7.0.5"
       },
       "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
         "broccoli-funnel": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
@@ -7291,25 +7276,6 @@
             "minimatch": "^3.0.0",
             "path-posix": "^1.0.0",
             "walk-sync": "^2.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
           }
         },
         "broccoli-plugin": {
@@ -7336,16 +7302,6 @@
             "ms": "2.1.2"
           }
         },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          }
-        },
         "fs-tree-diff": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
@@ -7357,17 +7313,6 @@
             "object-assign": "^4.1.0",
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
           }
         },
         "matcher-collection": {
@@ -7386,18 +7331,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "postcss": {
-          "version": "8.1.4",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.4.tgz",
-          "integrity": "sha512-LfqcwgMq9LOd8pX7K2+r2HPitlIGC5p6PoZhVELlqhh2YGDVcXKpkCseqan73Hrdik6nBd2OvoDPUaP/oMj9hQ==",
-          "dev": true,
-          "requires": {
-            "colorette": "^1.2.1",
-            "line-column": "^1.0.2",
-            "nanoid": "^3.1.15",
-            "source-map": "^0.6.1"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7405,37 +7338,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
           }
         },
         "walk-sync": {
@@ -7453,9 +7355,9 @@
       }
     },
     "broccoli-postcss-single": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-postcss-single/-/broccoli-postcss-single-5.0.0.tgz",
-      "integrity": "sha512-u8o00CadIDnwQkE4tGqxwK5rXgWVTeB8xh1yDk0ZLy2JNMfI5EhbHr+A1HZpfe40Xy5IBmQ7VlbU9aIrCP2R8Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-postcss-single/-/broccoli-postcss-single-4.0.1.tgz",
+      "integrity": "sha512-WfIKXqkTNyA0OJuJKoUJ2TxerRvtkiwYEK8KY5gHGr/GGqPHYWVnAUN5/O8/LWBNhgr9M94KstpXe+GqXyEflA==",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "^3.0.3",
@@ -7463,31 +7365,13 @@
         "minimist": ">=1.2.5",
         "mkdirp": "^1.0.3",
         "object-assign": "^4.1.1",
-        "postcss": "^8.1.4"
+        "postcss": "^7.0.0"
       },
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "8.1.4",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.4.tgz",
-          "integrity": "sha512-LfqcwgMq9LOd8pX7K2+r2HPitlIGC5p6PoZhVELlqhh2YGDVcXKpkCseqan73Hrdik6nBd2OvoDPUaP/oMj9hQ==",
-          "dev": true,
-          "requires": {
-            "colorette": "^1.2.1",
-            "line-column": "^1.0.2",
-            "nanoid": "^3.1.15",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -12530,15 +12414,15 @@
       "dev": true
     },
     "ember-cli-postcss": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-postcss/-/ember-cli-postcss-7.0.0.tgz",
-      "integrity": "sha512-qvVMwC3pMbyrQAlDU9xKGBAjzCo3A/Tm+C5FrrTW2jW3SEgH8KGzuEH26oLAoT/aEb0wxNg/X5IqcTH6y/ID1w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-postcss/-/ember-cli-postcss-6.0.1.tgz",
+      "integrity": "sha512-xnqcFE9/OdfnxqisLHys7VZLzzSSGg96fzTCL+E/q2RqvFmtUC9FRP1sXtt7/UCogB1m4cdqYeW/a0VD8zBgPg==",
       "dev": true,
       "requires": {
         "broccoli-file-creator": "^2.1.1",
         "broccoli-merge-trees": "^4.0.0",
-        "broccoli-postcss": "^6.0.0",
-        "broccoli-postcss-single": "^5.0.0",
+        "broccoli-postcss": "^5.1.0",
+        "broccoli-postcss-single": "^4.0.0",
         "ember-cli-babel": "^7.1.0",
         "merge": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-htmlbars": "^4.0.5",
     "ember-cli-image-transformer": "^4.0.3",
     "ember-cli-inject-live-reload": "^2.0.1",
-    "ember-cli-postcss": "^7.0.0",
+    "ember-cli-postcss": "^6.0.1",
     "ember-cli-server-variables": "2.4.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",


### PR DESCRIPTION
the 7.x version of ember-cli-postcss blows up the build on my local env in spectacular fashion. i'm rolling this back.